### PR TITLE
Don't Hardcode the Username in sudoers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,19 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.1] - 2019-01-16
+
+### Fixed
+
+* The username in the `sudoers` file is no longer hardcoded to `ansible` and will instead honour the
+  value of `ansible_pull_username`.
+
+## [0.1.0] - 2019-01-15
+
+* Initial commit

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# ansible_pull
+# ansible_pull [![Build Status](https://github.com/DWSR/ansible-pull/workflows/CI/badge.svg?branch=master)](https://github.com/DWSR/ansible-pull/actions?query=workflow%3ACI)
 
 An Ansible role to install and configure ansible-pull
 

--- a/files/sudoers_ansible
+++ b/files/sudoers_ansible
@@ -1,3 +1,0 @@
-Defaults:ansible !requiretty
-
-%ansible ALL=(ALL) NOPASSWD: ALL

--- a/molecule/default/tests/test_add_deploy_key.py
+++ b/molecule/default/tests/test_add_deploy_key.py
@@ -9,7 +9,7 @@ testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
 
 
 def test_known_hosts_does_not_exist(host):
-    u = host.user("ansible")
+    u = host.user("elbisna")
     ssh_known_hosts = host.file(f"{u.home}/.ssh/known_hosts")
 
     assert not ssh_known_hosts.exists

--- a/molecule/default/tests/test_create_user.py
+++ b/molecule/default/tests/test_create_user.py
@@ -9,30 +9,30 @@ testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
 
 
 def test_account(host):
-    u = host.user("ansible")
+    u = host.user("elbisna")
     assert u.uid <= 1000
-    assert "ansible" in u.groups
-    assert "ansible" in u.group
+    assert "elbisna" in u.groups
+    assert "elbisna" in u.group
     assert u.shell == "/bin/bash"
 
     ssh_key = host.file(f"{u.home}/.ssh/id_ed25519")
 
     assert ssh_key.mode == 0o600
-    assert ssh_key.user == "ansible"
-    assert ssh_key.group == "ansible"
+    assert ssh_key.user == "elbisna"
+    assert ssh_key.group == "elbisna"
     assert ssh_key.contains("-----BEGIN OPENSSH PRIVATE KEY-----")
     assert ssh_key.contains("-----END OPENSSH PRIVATE KEY-----")
 
     ssh_pub_key = host.file(f"{u.home}/.ssh/id_ed25519.pub")
 
     assert ssh_pub_key.mode == 0o644
-    assert ssh_pub_key.user == "ansible"
-    assert ssh_pub_key.group == "ansible"
+    assert ssh_pub_key.user == "elbisna"
+    assert ssh_pub_key.group == "elbisna"
     assert ssh_pub_key.contains("ssh-ed25519")
     assert ssh_pub_key.contains("ansible-generated")
 
 
 def test_pwless_sudo(host):
-    with host.sudo("ansible"):
+    with host.sudo("elbisna"):
         with host.sudo():
             host.run_expect([0], "echo 'Hello, world!'")

--- a/molecule/default/tests/test_install_venv.py
+++ b/molecule/default/tests/test_install_venv.py
@@ -6,7 +6,7 @@ import testinfra.utils.ansible_runner
 
 testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
     os.environ["MOLECULE_INVENTORY_FILE"]
-).get_hosts("all:!centos-7")
+).get_hosts("all")
 
 
 @pytest.mark.parametrize(
@@ -17,8 +17,8 @@ def test_directory(host, path):
 
     assert f.exists
     assert f.is_directory
-    assert f.user == "ansible"
-    assert f.group == "ansible"
+    assert f.user == "elbisna"
+    assert f.group == "elbisna"
 
 
 @pytest.mark.parametrize("package_name", [("ansible"), ("passlib"), ("proxmoxer")])
@@ -42,8 +42,8 @@ def test_running_ansible_pull(host):
     f = host.file(pull_script)
 
     assert f.exists
-    assert f.user == "ansible"
-    assert f.group == "ansible"
+    assert f.user == "elbisna"
+    assert f.group == "elbisna"
     assert f.mode == 0o700
 
     assert host.run_expect([0], pull_script)

--- a/molecule/default/tests/test_vaults.py
+++ b/molecule/default/tests/test_vaults.py
@@ -17,8 +17,8 @@ def test_directory(host, path):
 
     assert f.exists
     assert f.is_directory
-    assert f.user == "ansible"
-    assert f.group == "ansible"
+    assert f.user == "elbisna"
+    assert f.group == "elbisna"
 
 
 @pytest.mark.parametrize("path", ["/opt/ansible/.ansible/.vault/test"])
@@ -27,7 +27,7 @@ def test_vault(host, path):
 
     assert f.exists
     assert f.is_file
-    assert f.user == "ansible"
-    assert f.group == "ansible"
+    assert f.user == "elbisna"
+    assert f.group == "elbisna"
     assert f.mode == 0o600
     assert f.content_string == "ansiblepull"

--- a/molecule/resources/inventories/default.yml
+++ b/molecule/resources/inventories/default.yml
@@ -17,6 +17,7 @@ all:
   vars:
     ansible_pull_extra_packages:
       proxmoxer: 1.0.3
+    ansible_pull_username: elbisna
     ansible_pull_inventory: inventory.yml
     ansible_pull_playbook: playbook_encrypted.yml
     ansible_pull_repo_url: file:///tmp/ansible-repo

--- a/tasks/create_user.yml
+++ b/tasks/create_user.yml
@@ -21,7 +21,7 @@
   register: ansible_account
 
 - name: Grant Ansible passwordless sudo
-  copy:
-    src: sudoers_ansible
+  template:
+    src: sudoers_ansible.j2
     dest: /etc/sudoers.d/ansible
     mode: 0440

--- a/templates/sudoers_ansible.j2
+++ b/templates/sudoers_ansible.j2
@@ -1,0 +1,3 @@
+Defaults:{{ ansible_pull_username }} !requiretty
+
+%{{ ansible_pull_username }} ALL=(ALL) NOPASSWD: ALL


### PR DESCRIPTION
This change makes the username in the sudoers file created by
`create_user.yml` a templated value. Previously, it was hardcoded to
`ansible`.