### PR TITLE
Fix Crontab Specifying Wrong Wrapper Path

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
         id: setup-python
         uses: actions/setup-python@v1
         with:
-          python-version: '3.8.0'
+          python-version: '3.8'
       - name: Install poetry
         id: install-poetry
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## Unreleased
+
+## [0.1.2] - 2020-05-11
+
+### Fixed
+
+* When using the `cron` timer method, calculate the path of the wrapper script
+  correctly.
 
 ## [0.1.1] - 2019-01-16
 

--- a/molecule/unprivileged/molecule.yml
+++ b/molecule/unprivileged/molecule.yml
@@ -7,7 +7,7 @@ lint:
   name: yamllint
 platforms:
   - name: ubuntu-1604
-    image: dwsr/molecule-ubuntu-1604:20200112
+    image: dwsr/molecule-ubuntu-1604:20200510
     command: /sbin/init
     dockerfile: ../resources/docker/unprivileged.Dockerfile.j2
     tmpfs:
@@ -17,7 +17,7 @@ platforms:
     groups:
       - ubuntu
   - name: ubuntu-1804
-    image: dwsr/molecule-ubuntu-1804:20200112
+    image: dwsr/molecule-ubuntu-1804:20200510
     command: /sbin/init
     dockerfile: ../resources/docker/unprivileged.Dockerfile.j2
     tmpfs:
@@ -27,7 +27,7 @@ platforms:
     groups:
       - ubuntu
   - name: debian-9
-    image: dwsr/molecule-debian-9:20200112
+    image: dwsr/molecule-debian-9:20200510
     command: /sbin/init
     dockerfile: ../resources/docker/unprivileged.Dockerfile.j2
     tmpfs:
@@ -37,7 +37,7 @@ platforms:
     groups:
       - debian
   - name: debian-10
-    image: dwsr/molecule-debian-10:20200112
+    image: dwsr/molecule-debian-10:20200510
     command: /sbin/init
     dockerfile: ../resources/docker/unprivileged.Dockerfile.j2
     tmpfs:
@@ -47,7 +47,7 @@ platforms:
     groups:
       - debian
   - name: centos-7
-    image: dwsr/molecule-centos-7:20200112
+    image: dwsr/molecule-centos-7:20200510
     command: /sbin/init
     dockerfile: ../resources/docker/unprivileged.Dockerfile.j2
     tmpfs:
@@ -57,7 +57,7 @@ platforms:
     groups:
       - centos_7
   - name: centos-8
-    image: dwsr/molecule-centos-8:20200112
+    image: dwsr/molecule-centos-8:20200510
     command: /sbin/init
     dockerfile: ../resources/docker/unprivileged.Dockerfile.j2
     tmpfs:

--- a/molecule/unprivileged/tests/test_default.py
+++ b/molecule/unprivileged/tests/test_default.py
@@ -49,7 +49,7 @@ def test_crontab(host):
         f = host.file("/var/spool/cron/crontabs/elbisna")
         group = "crontab"
 
-    entry = "*/15 * * * * /home/elbisna/.ansible/do_ansible_pull > /dev/null 2>&1"
+    entry = "*/15 * * * * /home/elbisna/bin/do_ansible_pull > /dev/null 2>&1"
 
     assert f.exists
     assert f.is_file

--- a/tasks/timer_cron.yml
+++ b/tasks/timer_cron.yml
@@ -3,7 +3,7 @@
     backup: true
     name: 'Ansible Pull run'
     job: >
-      {{ ansible_pull_config_path }}/do_ansible_pull
+      {{ ansible_pull_install_path }}/do_ansible_pull
       > /dev/null 2>&1
     minute: "{{ ansible_pull_crontab_schedule['minute'] | default('*/5') }}"
     hour: "{{ ansible_pull_crontab_schedule['hour'] | default('*') }}"


### PR DESCRIPTION
This change fixes the cron timer method specifying the wrong path to the
wrapper script for launching `ansible-pull`.